### PR TITLE
Sync Arglab/ETS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,6 @@ install_requires =
   srsly
   wordfreq
   nltk
-  varname
+  varname<0.14.0
 [options.package_data]
 * = *.cfg, *.csv, *.json, *.txt


### PR DESCRIPTION
Looks like the only change was a dependency version lock for varname (Jan 2025).